### PR TITLE
README: fix missing likes and typo in author field name

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ query {
    title : String
    year : Number
    author : Author
+   likes : Number
  }
 
  type Author {

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ _checkout la branche question-3_
 
 **But:** Créer un service graphQL qui réponde à ces deux requêtes:
 ```
-// le titre, année et autheur (nom, prénom) du livre d'id 2
+// le titre, année, likes et auteur (nom, prénom) du livre d'id 2
 
 query {
   book(id : 2) {


### PR DESCRIPTION
- `likes` was in the query but missing in the description
- `autheur` is neither french nor english 🙂 